### PR TITLE
Refine CI workflow for testing on GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,11 +3,7 @@ name: tests
 on:
   push:
     branches:
-       - '*'         # matches every branch that doesn't contain a '/'
-       - '*/*'       # matches every branch containing a single '/'
-       - '**'        # matches every branch
-       - '!master'   # excludes master# Default release branch
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+       - 'test'         # matches every branch that doesn't contain a '/'      
 jobs:
   # This workflow contains a single job called "build"
   build:
@@ -15,31 +11,28 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: [ '8.0.x' ]       
+        dotnet-version: [ '6.0.x', '7.0.x','8.0.x' ]
       # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v2
       - name: Setup dotnet ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
+        id: stepid
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
           include-prerelease: true
+
+      - name: Create temporary global.json
+        run: |
+          echo '{"sdk":{"version": "${{ matrix.dotnet-version }}"}}' > ./global.json
+        shell: bash
       # You can test your matrix by printing the current dotnet version
       - name: Display dotnet version
         run: dotnet --version
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet test
+ 
       - name: Build
-        run: dotnet build --configuration Release --no-restore
-      - name: Set up MySQL
-        uses: mirromutth/mysql-action@v1.1
-        with:
-          host port: 3800 # Optional, default value is 3306. The port of host
-          container port: 3307 # Optional, default value is 3306. The port of container
-          character set server: 'utf8' # Optional, default value is 'utf8mb4'. The '--character-set-server' option for mysqld
-          collation server: 'utf8_general_ci' # Optional, default value is 'utf8mb4_general_ci'. The '--collation-server' option for mysqld
-          mysql version: '8.0' # Optional, default value is "latest". The version of the MySQL
-          mysql database: 'some_test' # Optional, default value is "test". The specified database which will be create
-          mysql root password: 'root' # Required if "mysql user" is empty, default is empty. The root superuser password
-          mysql user: 'developer' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
-          mysql password: 'root' # Required if "mysql user" exists. The password for the "mysql user"
+        # build dotnet with output ./build.zip
+        run: dotnet build --configuration Release #--no-restore #--output ./build.zip
+     


### PR DESCRIPTION
- Narrow branch trigger to only 'test' branch.

- Expand matrix to test against .NET 6.0.x, 7.0.x, and 8.0.x.

- Update GitHub Actions for dotnet to version 4.

- Shift from restore and build to direct testing.

- Include dynamic global.json creation for SDK version consistency.